### PR TITLE
名刺詳細画面 mail telリンク追加

### DIFF
--- a/app/assets/javascripts/common/card.js
+++ b/app/assets/javascripts/common/card.js
@@ -1,4 +1,23 @@
 $(function(){
+  // ---------------
+  // スマートフォンの場合のみ、card/showの電話ボタンが機能します。
+  // 参考 https://webliker.info/65145/
+  // https://qiita.com/shouchida/items/a057a869003e4e2eb009
+  var ua = navigator.userAgent.toLowerCase();
+  // uaはこのアプリを使っているブラウザの情報が全部小文字で入ります。
+  var isMobile = /iphone/.test(ua)||/android(.+)?mobile/.test(ua);
+  //ua内にiphoneやandroidでmobileが入っているならtrue。PCならisMobileはtrue
+  if (!isMobile) {
+    // 念の為、スマートフォンでこのアプリを使用していないなら、電話アイコンを非表示にします。
+      $('#showcard_left_icon_tel').css('visibility','hidden');
+      // 以下は実際にアイコンを押された場合、(aタグでhref属性値がtel:で始まるもの(^=))イベントを無効にします。
+      // https://developer.mozilla.org/ja/docs/Web/CSS/Attribute_selectors
+      $('a[href^="tel:"]').on('click', function(e) {
+         e.preventDefault();
+         alert('この機能はPCではなく、スマートフォンでご使用になれます。');
+      });
+  }
+  // ---------------
   function buildNormalSearchResult(cards_inGroup,cards_inUser){
     var returnHTML=``;
         if ((cards_inGroup.length > 0)||(cards_inUser.length > 0)){

--- a/app/assets/javascripts/common/card.js
+++ b/app/assets/javascripts/common/card.js
@@ -70,7 +70,13 @@ $(function(){
   $('#card_address').attr('placeholder','住所を入力');
   $('#card_tel').attr('placeholder','電話番号を入力');
   $('#card_email').attr('placeholder','メールアドレスを入力');
+
+  $('#showcard_left_icon_company').css('display','none');
+  $('#showcard_left_icon_address').css('display','none');
+  $('#showcard_left_icon_tel').css('display','none');
+  $('#showcard_left_icon_email').css('display','none');
   });
+
   $('#card__rebertedit').on('click',function(){
     // 名刺情報の編集をやめるボタンを押したとき
   $('#card__startedit').css('visibility','visible');
@@ -78,6 +84,12 @@ $(function(){
   $('#card__updatebtn').css('visibility','hidden');
   $('#card__rebertedit').css('visibility','hidden');
   $('#card__destroybtn').css('visibility','visible');
+  
+  $('#showcard_left_icon_company').css('display','block');
+  $('#showcard_left_icon_address').css('display','block');
+  $('#showcard_left_icon_tel').css('display','block');
+  $('#showcard_left_icon_email').css('display','block');
+
   window.location.reload();
   });
   $('#searchnormform-inner__form').on('submit',function(e){

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@
 @import "modules/card_searchnormalform";
 @import "modules/episode_show";
 @import "modules/card_newcamerasearchcamera";
+@import "modules/card_searchcompany";
 @import "modules/group_new";
 @import "modules/btnrad";
 @import "modules/notification";

--- a/app/assets/stylesheets/modules/_card_searchcompany.scss
+++ b/app/assets/stylesheets/modules/_card_searchcompany.scss
@@ -1,0 +1,47 @@
+.searchcompany-outer{
+  width:100%;
+  height:calc(100vh - 150px);
+  background-color:$backLightGray;
+  .searchcompany-inner{
+    width:95%;
+    background-color:$mainWhite;
+    margin:0 auto;
+    height:100%;
+    display:block;
+    padding-left:30px;
+    padding-right:30px;
+    &__results{
+      height:100%;
+      &--Group{
+        padding:0 2px 0 2px;
+        height:45%;
+        overflow:scroll;
+        border:1px solid black;
+        margin:2px 0 2px 0;
+      }
+      &--User{
+        padding:0 2px 0 2px;
+        height:45%;
+        overflow:scroll;
+        border:1px solid black;
+        margin:2px 0 2px 0;
+      }
+      &__row{
+        display:flexbox;
+        justify-content: flex-start;
+        &--title{
+          margin-top:5px;
+          text-align: center;
+        }
+        &--number{
+          width:30px;
+          margin-left:5px;
+        }
+        &--link{
+          font-size:0.8em;
+          padding:5px;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/_card_show.scss
+++ b/app/assets/stylesheets/modules/_card_show.scss
@@ -24,6 +24,17 @@
         &--input{
           width:50%;
         }
+        &__company,&__address,&__email,&__tel{
+          width:50%;
+          display:flex;
+          &--value{
+            width:90%;
+          }
+          &--icon{
+            width:10%;
+            text-align: center;
+          }
+        }
       }
       &--subtitle{
         &--em{

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -21,7 +21,15 @@ class CardsController < ApplicationController
     @cards_inUser=Card.includes(:user).where(user_id: current_user.id).where("name like ?", "%#{params[:name]}%").where("company like ?", "%#{params[:company]}%").where("department like ?", "%#{params[:department]}%").where("address like ?", "%#{params[:address]}%").where("tel like ?", "%#{params[:tel]}%").where("email like ?", "%#{params[:email]}%")
     @cards_inGroup=Card.includes(:group).where(group_id: current_user.group_id).where.not(user_id: current_user.id).where("name like ?", "%#{params[:name]}%").where("company like ?", "%#{params[:company]}%").where("department like ?", "%#{params[:department]}%").where("address like ?", "%#{params[:address]}%").where("tel like ?", "%#{params[:tel]}%").where("email like ?", "%#{params[:email]}%")
   end
- 
+  def searchcompany
+    # このアクションはcards/show内の会社検索ボタンを押されたときの結果です。
+    puts"---searchcompany----"
+    puts params
+    @searchword=params[:searchcompanyname]
+    @cards_inUser=Card.includes(:user).where(user_id: current_user.id).where("company like ?", @searchword)
+    @cards_inGroup=Card.includes(:group).where(group_id: current_user.group_id).where.not(user_id: current_user.id).where("company like ?", @searchword)
+    # binding.pry
+  end
   def searchajax
     # GoogleCloudAPIからの認識結果と、先頭から何文字を検索用文字とするかを設定してクラスメソッドへ=>cardsのapiresulthash値に対応する値をつくります。
     searchapiresulthash=Card.createApiresulthash(params[:test],70)

--- a/app/views/cards/_searchcardresults.html.haml
+++ b/app/views/cards/_searchcardresults.html.haml
@@ -1,0 +1,9 @@
+.searchcompany-inner__results__row
+  =text_field_tag "No",index+1,readonly: true,class:"searchcompany-inner__results__row--number"
+  =text_field_tag "name",card.name,readonly: true,class:"searchcompany-inner__results__row--name"
+  =text_field_tag "company",card.company,readonly: true,class:"searchcompany-inner__results__row--company"
+  =text_field_tag "department",card.department,readonly: true,class:"searchcompany-inner__results__row--deparment"
+  =text_field_tag "address",card.address,readonly: true,class:"searchcompany-inner__results__row--address"
+  =text_field_tag "tel",card.tel,readonly: true,class:"searchcompany-inner__results__row--tel"
+  =text_field_tag "email",card.email,readonly: true,class:"searchcompany-inner__results__row--email"
+  =link_to "詳細",card_path(card.id),class:"searchcompany-inner__results__row--link btnrad btnrad--blue"

--- a/app/views/cards/searchcompany.html.haml
+++ b/app/views/cards/searchcompany.html.haml
@@ -1,0 +1,27 @@
+= render 'partial/header'
+= render 'layouts/notifications'
+.searchcompany-outer
+  .searchcompany-inner
+    .searchcompany-inner__results
+      -if ((@cards_inGroup.length > 0)||(@cards_inUser.length > 0))
+        .searchcompany-inner__results__row
+          %p.searchcompany-inner__results__row--title
+            会社名が「#{@searchword}」の 検索結果 (全 #{@cards_inGroup.length + @cards_inUser.length} 件)
+          =text_field_tag "No","",readonly: true,class:"searchcompany-inner__results__row--number"
+          =text_field_tag "name","名前",readonly: true,class:"searchcompany-inner__results__row--name"
+          =text_field_tag "company","会社名",readonly: true,class:"searchcompany-inner__results__row--company"
+          =text_field_tag "department","部署名",readonly: true,class:"searchcompany-inner__results__row--deparment"
+          =text_field_tag "address","住所",readonly: true,class:"searchcompany-inner__results__row--address"
+          =text_field_tag "tel","TEL",readonly: true,class:"searchcompany-inner__results__row--tel"
+          =text_field_tag "email","mail",readonly: true,class:"searchcompany-inner__results__row--email"
+        -if @cards_inGroup.length > 0
+          .searchcompany-inner__results--Group
+            所属グループで登録の名刺 #{@cards_inGroup.length}件
+            -@cards_inGroup.each_with_index do |card,index|
+              =render partial: "searchcardresults",locals:{card: card,index: index}
+        -if @cards_inUser.length > 0
+          .searchcompany-inner__results--User
+            あなたが個人として登録済みの名刺 #{@cards_inUser.length}件
+            -@cards_inUser.each_with_index do |card,index|
+              =render partial: "searchcardresults",locals:{card: card,index: index}
+= render 'partial/footer'

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -10,19 +10,31 @@
         =f.text_field :name,class:"showcard_left__cardform__row--input",value:@card.name,readonly:"true"
       .showcard_left__cardform__row
         =f.label :会社名,class:"showcard_left__cardform__row--label"
-        =f.text_field :company,class:"showcard_left__cardform__row--input",value:@card.company,readonly:"true"
+        .showcard_left__cardform__row__company
+          =f.text_field :company,class:"showcard_left__cardform__row--input showcard_left__cardform__row__company--value",value:@card.company,readonly:"true"
+          -if @card.company!=(nil or "")
+            =link_to icon('fas','search'),searchcompany_cards_path(searchcompanyname: @card.company,cardid: @card.id), method: :post,class:"showcard_left__cardform__row__company--icon btnrad btnrad--blue",id:"showcard_left_icon_company"
       .showcard_left__cardform__row
         =f.label :部署名,class:"showcard_left__cardform__row--label"
         =f.text_field :department,class:"showcard_left__cardform__row--input",value:@card.department,readonly:"true"
       .showcard_left__cardform__row
         =f.label :住所,class:"showcard_left__cardform__row--label"
-        =f.text_field :address,class:"showcard_left__cardform__row--input",value:@card.address
+        .showcard_left__cardform__row__address
+          =f.text_field :address,class:"showcard_left__cardform__row--input showcard_left__cardform__row__address--value",value:@card.address,readonly:"true"
+          -if @card.address!=(nil or "")
+            =link_to icon('fas','map-marked-alt'),"https://www.google.co.jp/maps/place/#{@card.address}",class:"showcard_left__cardform__row__address--icon btnrad btnrad--blue",id:"showcard_left_icon_address"
       .showcard_left__cardform__row
         =f.label :電話番号,class:"showcard_left__cardform__row--label"
-        =f.text_field :tel,class:"showcard_left__cardform__row--input",value:@card.tel
+        .showcard_left__cardform__row__tel
+          =f.text_field :tel,class:"showcard_left__cardform__row--input showcard_left__cardform__row__tel--value",value:@card.tel,readonly:"true"
+          -if @card.tel!=(nil or "")
+            =link_to icon('fas','phone-volume'),"tel:#{@card.tel}",class:"showcard_left__cardform__row__tel--icon btnrad btnrad--blue",id:"showcard_left_icon_tel"
       .showcard_left__cardform__row
         =f.label :メールアドレス,class:"showcard_left__cardform__row--label"
-        =f.text_field :email,class:"showcard_left__cardform__row--input",value:@card.email
+        .showcard_left__cardform__row__email
+          =f.text_field :email,class:"showcard_left__cardform__row--input showcard_left__cardform__row__email--value",value:@card.email,readonly:"true"
+          -if @card.email != (nil or "")
+            =link_to icon('fas','envelope'),"mailto:#{@card.email}",class:"showcard_left__cardform__row__email--icon btnrad btnrad--blue",id:"showcard_left_icon_email"
       .showcard_left__cardform__btns
         -if current_user.id == @card.user_id
           =f.submit "名刺データを更新",id:"card__updatebtn",class:"btnrad btnrad--anim"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
       post 'searchajax' ,to: 'cards#searchajax'
       get 'searchnormalform' ,to: 'cards#searchnormalform'
       post 'searchnormaltext',to: 'cards#searchnormaltext'
+      post 'searchcompany',to:'cards#searchcompany'
     end
   end
   


### PR DESCRIPTION
# what
名刺の詳細画面で、表示されているアドレスでメールが出せる、電話番号で電話できる、住所でgooglemapが立ち上がる、会社名で再検索できるようにしました。

# why
ローカル環境で動作を確認したため、本番環境にあげます。